### PR TITLE
Speed up sharing-aware extractor and fix spelling

### DIFF
--- a/plot.py
+++ b/plot.py
@@ -31,8 +31,8 @@ def process(js, extractors=[]):
     assert len(extractors) == 2
     e1, e2 = extractors
 
-    e1_cummulative=0
-    e2_cummulative=0
+    e1_cumulative=0
+    e2_cumulative=0
 
     summaries = {}
 
@@ -45,8 +45,8 @@ def process(js, extractors=[]):
             dag_ratio = d[e1]["dag"] / d[e2]["dag"]
             micros_ratio = max(1, d[e1]["micros"]) / max(1, d[e2]["micros"])
             
-            e1_cummulative += d[e1]["micros"];
-            e2_cummulative += d[e2]["micros"];
+            e1_cumulative += d[e1]["micros"];
+            e2_cumulative += d[e2]["micros"];
             
             summaries[name] = {
                 "tree": tree_ratio,
@@ -57,8 +57,8 @@ def process(js, extractors=[]):
             print(f"Error processing {name}")
             raise e
 
-    print(f"Cummulative time for {e1}: {e1_cummulative/1000:.0f}ms")
-    print(f"Cummulative time for {e2}: {e2_cummulative/1000:.0f}ms")
+    print(f"cumulative time for {e1}: {e1_cumulative/1000:.0f}ms")
+    print(f"cumulative time for {e2}: {e2_cumulative/1000:.0f}ms")
 
     print(f"{e1} / {e2}")
 


### PR DESCRIPTION
This PR reduces, on my machine, the runtime of the recently merged sharing-aware extractor (#10) from 8.8 seconds to 3.3 seconds.

```
Loaded 422 jsons.
extractors: ['faster-greedy-dag', 'greedy-dag']
data/tensat/nasneta.json 17954094932524.336 15994232636654.406
data/tensat/nasrnn.json 1158.6070294405508 930.8220652824966
data/egg/math_simplify_add.json 3 7
data/egg/math_diff_ln.json 3 4
cumulative time for faster-greedy-dag: 3314ms
cumulative time for greedy-dag: 47435ms
faster-greedy-dag / greedy-dag
geo mean
tree: 0.9962
dag: 1.0002
micros: 0.8128
quantiles
tree:   0.4286, 1.0000, 1.0000, 1.0000, 1.2447
dag:    0.9957, 1.0000, 1.0000, 1.0000, 1.0225
micros: 0.0284, 0.6061, 0.8866, 1.2203, 2.2857
```

Was previously:
```
Loaded 422 jsons.
extractors: ['faster-greedy-dag', 'greedy-dag']
data/tensat/nasneta_acyclic.json 16023614866670.953 16023517195541.84
data/tensat/nasrnn.json 1158.6070294405508 930.8220652824966
data/egg/math_simplify_add.json 3 7
Cummulative time for faster-greedy-dag: 8839ms
Cummulative time for greedy-dag: 47155ms
faster-greedy-dag / greedy-dag
geo mean
tree: 0.9970
dag: 1.0002
micros: 0.9750
quantiles
tree:   0.4286, 1.0000, 1.0000, 1.0000, 1.2447
dag:    0.9957, 1.0000, 1.0000, 1.0000, 1.0225
micros: 0.0910, 0.5888, 1.0630, 1.5546, 3.0305

```

It also fixes some spelling mistakes I introduced.

