### PR TITLE
Global DAG extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "archery"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487955f60962765486ce000015a3492ca45c34a2ebbf12bc0aa2b5110ca6e7d2"
+dependencies = [
+ "static_assertions",
+ "triomphe",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +92,7 @@ dependencies = [
  "log",
  "ordered-float",
  "pico-args",
+ "rpds",
 ]
 
 [[package]]
@@ -218,6 +229,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpds"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e15515d3ce3313324d842629ea4905c25a13f81953eadb88f85516f59290a4"
+dependencies = [
+ "archery",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +301,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ coin_cbc = { version = "0.1.6", optional = true }
 im-rc = "15.1.0"
 
 rpds = "1.1.0"
-
 [dependencies.egraph-serialize]
 git = "https://github.com/egraphs-good/egraph-serialize"
 rev = "951b829a434f4008c7b45ba4ac0da1037d2da90"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,17 @@ version = "0.1.0"
 ilp-cbc = ["coin_cbc"]
 
 [dependencies]
-env_logger = {version = "0.10.0", default-features = false}
+env_logger = { version = "0.10.0", default-features = false }
 indexmap = "2.0.0"
 log = "0.4.19"
 ordered-float = "3"
-pico-args = {version = "0.5.0", features = ["eq-separator"]}
+pico-args = { version = "0.5.0", features = ["eq-separator"] }
 
 anyhow = "1.0.71"
-coin_cbc = {version = "0.1.6", optional = true}
+coin_cbc = { version = "0.1.6", optional = true }
 im-rc = "15.1.0"
+
+rpds = "1.1.0"
 
 [dependencies.egraph-serialize]
 git = "https://github.com/egraphs-good/egraph-serialize"

--- a/plot.py
+++ b/plot.py
@@ -96,8 +96,9 @@ if __name__ == "__main__":
 
     extractors = sorted(set(j["extractor"] for j in js))
 
-    for ex1 in extractors:
-        for ex2 in extractors:
+    for i in range(len(extractors)):
+        for j in range(i + 1, len(extractors)):
+            ex1, ex2 = extractors[i], extractors[j]
             if ex1 == ex2:
                 continue
             print(f"###################################################\n{ex1} vs {ex2}\n\n")

--- a/plot.py
+++ b/plot.py
@@ -60,6 +60,11 @@ def process(js, extractors):
     print(f"cumulative time for {e1}: {e1_cumulative/1000:.0f}ms")
     print(f"cumulative time for {e2}: {e2_cumulative/1000:.0f}ms")
 
+    print(f"cumulative tree cost for {e1}: {sum(d[e1]['tree'] for d in by_name.values()):.0f}")
+    print(f"cumulative tree cost for {e2}: {sum(d[e2]['tree'] for d in by_name.values()):.0f}")
+    print(f"cumulative dag cost for {e1}: {sum(d[e1]['dag'] for d in by_name.values()):.0f}")
+    print(f"cumulative dag cost for {e2}: {sum(d[e2]['dag'] for d in by_name.values()):.0f}")
+
     print(f"{e1} / {e2}")
 
     print("geo mean")

--- a/plot.py
+++ b/plot.py
@@ -19,9 +19,7 @@ def load_jsons(files):
     return js
 
 
-def process(js, extractors=[]):
-    extractors = extractors or sorted(set(j["extractor"] for j in js))
-
+def process(js, extractors):
     by_name = {}
     for j in js:
         n, e = j["name"], j["extractor"]
@@ -39,7 +37,9 @@ def process(js, extractors=[]):
     for name, d in by_name.items():
         try:
             if d[e1]["tree"] !=  d[e2]["tree"]:
-                print(name, d[e1]["tree"], d[e2]["tree"]);
+                print(name, " differs in tree cost: ", d[e1]["tree"], d[e2]["tree"]);
+            if d[e1]["dag"] !=  d[e2]["dag"]:
+                print(name, " differs in dag cost: ", d[e1]["dag"], d[e2]["dag"]);
                 
             tree_ratio = d[e1]["tree"] / d[e2]["tree"]
             dag_ratio = d[e1]["dag"] / d[e2]["dag"]
@@ -56,7 +56,7 @@ def process(js, extractors=[]):
         except Exception as e:
             print(f"Error processing {name}")
             raise e
-
+ 
     print(f"cumulative time for {e1}: {e1_cumulative/1000:.0f}ms")
     print(f"cumulative time for {e2}: {e2_cumulative/1000:.0f}ms")
 
@@ -93,4 +93,13 @@ if __name__ == "__main__":
     files = sys.argv[1:] or glob.glob("output/**/*.json", recursive=True)
     js = load_jsons(files)
     print(f"Loaded {len(js)} jsons.")
-    process(js)
+
+    extractors = sorted(set(j["extractor"] for j in js))
+
+    for ex1 in extractors:
+        for ex2 in extractors:
+            if ex1 == ex2:
+                continue
+            print(f"###################################################\n{ex1} vs {ex2}\n\n")
+            process(js, [ex1, ex2])
+            print("\n\n")

--- a/src/extract/fast_greedy_dag.rs
+++ b/src/extract/fast_greedy_dag.rs
@@ -1,0 +1,157 @@
+use rpds::HashTrieSet;
+
+use super::*;
+
+type TermId = usize;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct Term {
+    op: String,
+    children: Vec<TermId>,
+}
+
+struct TermInfo {
+    node: NodeId,
+    node_cost: NotNan<f64>,
+    total_cost: NotNan<f64>,
+    reachable: HashTrieSet<TermId>,
+}
+
+// A TermDag needs to store terms that share common
+// subterms using a hashmap.
+// However, it also critically needs to be able to answer
+// reachability queries in this dag `reachable`.
+// This prevents double-counting costs when
+// computing the cost of a term.
+#[derive(Default)]
+pub struct TermDag {
+    nodes: Vec<Term>,
+    info: Vec<TermInfo>,
+    hash_cons: HashMap<Term, TermId>,
+}
+
+impl TermDag {
+    pub fn make(
+        &mut self,
+        node: NodeId,
+        op: String,
+        children: Vec<TermId>,
+        node_cost: NotNan<f64>,
+    ) -> TermId {
+        let term = Term {
+            op,
+            children: children.clone(),
+        };
+
+        if let Some(id) = self.hash_cons.get(&term) {
+            return *id;
+        }
+
+        let next_id = self.nodes.len();
+        if children.is_empty() {
+            let next_id = self.nodes.len();
+            self.nodes.push(term.clone());
+            self.info.push(TermInfo {
+                node,
+                node_cost,
+                total_cost: node_cost,
+                reachable: [next_id].iter().cloned().collect(),
+            });
+            self.hash_cons.insert(term, next_id);
+            next_id
+        } else {
+            let mut cost = node_cost + self.total_cost(children[0]);
+            let mut reachable = Box::new(self.info[children[0]].reachable.clone());
+            let next_id = self.nodes.len();
+            self.nodes.push(term.clone());
+
+            for child in children.iter().skip(1) {
+                let child_cost = self.get_cost(&mut reachable, *child);
+                cost += child_cost;
+            }
+
+            self.info.push(TermInfo {
+                node,
+                node_cost,
+                total_cost: cost,
+                reachable: *reachable,
+            });
+            self.hash_cons.insert(term, next_id);
+            next_id
+        }
+    }
+
+    // Recompute the cost of this term, but don't count shared
+    // subterms.
+    fn get_cost(&self, shared: &HashTrieSet<TermId>, id: TermId) -> NotNan<f64> {
+        if shared.contains(&id) {
+            NotNan::<f64>::new(0.0).unwrap()
+        } else {
+            let mut cost = self.term_cost(id);
+            for child in &self.nodes[id].children {
+                cost += self.get_cost(shared, *child);
+            }
+            cost
+        }
+    }
+
+    pub fn term_cost(&self, id: TermId) -> NotNan<f64> {
+        self.info[id].node_cost
+    }
+
+    pub fn total_cost(&self, id: TermId) -> NotNan<f64> {
+        self.info[id].total_cost
+    }
+}
+
+pub struct GreedyDagExtractor;
+impl Extractor for GreedyDagExtractor {
+    fn extract(&self, egraph: &EGraph, _roots: &[ClassId]) -> ExtractionResult {
+        let mut keep_going = true;
+
+        let mut nodes = egraph.nodes.clone();
+        let mut termdag = TermDag::default();
+        let mut best_in_class: HashMap<ClassId, TermId> = HashMap::default();
+
+        let mut i = 0;
+        while keep_going {
+            i += 1;
+            println!("iteration {}", i);
+            keep_going = false;
+
+            'node_loop: for (node_id, node) in &nodes {
+                let node_cost = node.cost;
+                let mut children: Vec<TermId> = vec![];
+                // compute the cost set from the children
+                for child in &node.children {
+                    let child_cid = egraph.nid_to_cid(child);
+                    if let Some(best) = best_in_class.get(child_cid) {
+                        children.push(*best);
+                    } else {
+                        continue 'node_loop;
+                    }
+                }
+
+                let candidate = termdag.make(node_id.clone(), node.op.clone(), children, node_cost);
+                let cadidate_cost = termdag.total_cost(candidate);
+
+                if let Some(old_term) = best_in_class.get(&node.eclass) {
+                    let old_cost = termdag.total_cost(*old_term);
+                    if cadidate_cost < old_cost {
+                        best_in_class.insert(node.eclass.clone(), candidate);
+                        keep_going = true;
+                    }
+                } else {
+                    best_in_class.insert(node.eclass.clone(), candidate);
+                    keep_going = true;
+                }
+            }
+        }
+
+        let mut result = ExtractionResult::default();
+        for (class, term) in best_in_class {
+            result.choose(class, termdag.info[term].node.clone());
+        }
+        result
+    }
+}

--- a/src/extract/global_greedy_dag.rs
+++ b/src/extract/global_greedy_dag.rs
@@ -88,8 +88,7 @@ impl TermDag {
                 .unwrap();
 
             let mut cost = node_cost + self.total_cost(children[biggest_child]);
-            // wrap in a box so that we can mutate it during the loop
-            let mut reachable = Box::new(self.info[children[biggest_child]].reachable.clone());
+            let mut reachable = self.info[children[biggest_child]].reachable.clone();
             let next_id = self.nodes.len();
 
             for child in children.iter() {
@@ -104,14 +103,14 @@ impl TermDag {
                 return None;
             }
 
-            *reachable = reachable.insert(node.eclass.clone());
+            reachable = reachable.insert(node.eclass.clone());
 
             self.info.push(TermInfo {
                 node: node_id,
                 node_cost,
                 eclass: node.eclass.clone(),
                 total_cost: cost,
-                reachable: *reachable,
+                reachable,
                 size: 1 + children.iter().map(|c| self.info[*c].size).sum::<usize>(),
             });
             self.nodes.push(term.clone());
@@ -122,7 +121,7 @@ impl TermDag {
 
     /// Return a new term, like this one but making use of shared terms.
     /// Also return the cost of the new nodes.
-    fn get_cost(&self, shared: &mut Box<Reachable>, id: TermId) -> Cost {
+    fn get_cost(&self, shared: &mut Reachable, id: TermId) -> Cost {
         let eclass = self.info[id].eclass.clone();
 
         // This is the key to why this algorithm is faster than greedy_dag.
@@ -138,7 +137,7 @@ impl TermDag {
                 let child_cost = self.get_cost(shared, *child);
                 cost += child_cost;
             }
-            **shared = shared.insert(eclass);
+            *shared = shared.insert(eclass);
             cost
         }
     }

--- a/src/extract/global_greedy_dag.rs
+++ b/src/extract/global_greedy_dag.rs
@@ -88,6 +88,7 @@ impl TermDag {
                 .unwrap();
 
             let mut cost = node_cost + self.total_cost(children[biggest_child]);
+            // wrap in a box so that we can mutate it during the loop
             let mut reachable = Box::new(self.info[children[biggest_child]].reachable.clone());
             let next_id = self.nodes.len();
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 pub use crate::*;
 
 pub mod bottom_up;
+pub mod fast_greedy_dag;
 pub mod greedy_dag;
 pub mod greedy_dag_1;
 

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 pub use crate::*;
 
 pub mod bottom_up;
-pub mod fast_greedy_dag;
+pub mod global_greedy_dag;
 pub mod greedy_dag;
 pub mod greedy_dag_1;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() {
     env_logger::init();
 
     let extractors: IndexMap<&str, Box<dyn Extractor>> = [
+        ("bottom-up", extract::bottom_up::BottomUpExtractor.boxed()),
         (
             "greedy-dag",
             extract::greedy_dag::GreedyDagExtractor.boxed(),
@@ -26,6 +27,10 @@ fn main() {
         (
             "faster-greedy-dag",
             extract::greedy_dag_1::FasterGreedyDagExtractor.boxed(),
+        ),
+        (
+            "global-greedy-dag",
+            extract::global_greedy_dag::GlobalGreedyDagExtractor.boxed(),
         ),
     ]
     .into_iter()


### PR DESCRIPTION
This PR adds another greedy DAG extractor which improves the performance of calculating a term's cost.
It does this by sharing subterms in a global DAG, and exiting early when doing set unions.

```
cumulative time for bottom-up: 2474ms
cumulative time for global-greedy-dag: 4239ms
cumulative time for greedy-dag:            35011ms
cumulative dag cost for global-greedy-dag: 76907
cumulative dag cost for greedy-dag:             76907
```