### PR TITLE
Use a map that is faster with integer keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ pico-args = {version = "0.5.0", features = ["eq-separator"]}
 anyhow = "1.0.71"
 coin_cbc = {version = "0.1.6", optional = true}
 im-rc = "15.1.0"
+rustc-hash = "1.1.0"
 
 [dependencies.egraph-serialize]
 git = "https://github.com/egraphs-good/egraph-serialize"

--- a/src/extract/greedy_dag.rs
+++ b/src/extract/greedy_dag.rs
@@ -1,7 +1,8 @@
 use super::*;
+use rustc_hash::FxHashMap;
 
 struct CostSet {
-    costs: std::collections::HashMap<ClassId, Cost>,
+    costs: FxHashMap<ClassId, Cost>,
     total: Cost,
     choice: NodeId,
 }
@@ -25,7 +26,7 @@ impl Extractor for GreedyDagExtractor {
             'node_loop: for (node_id, node) in &nodes {
                 let cid = egraph.nid_to_cid(node_id);
                 let mut cost_set = CostSet {
-                    costs: std::collections::HashMap::new(),
+                    costs: FxHashMap::default(),
                     total: Cost::default(),
                     choice: node_id.clone(),
                 };


### PR DESCRIPTION
While I was working through the comments on my pull requests, I noticed that the greedy_dag uses the std hashmap which is slow with integer keys. This patch speeds it up by about 30%. Here is the comparison:
```
Loaded 512 jsons.
extractors: ['fx-greedy-dag', 'hashmap-greedy-dag']
cumulative time for fx-greedy-dag: 36099ms
cumulative time for hashmap-greedy-dag: 53058ms
fx-greedy-dag / hashmap-greedy-dag
geo mean
tree: 1.0000
dag: 1.0000
micros: 0.8621
quantiles
tree:   1.0000, 1.0000, 1.0000, 1.0000, 1.0000
dag:    1.0000, 1.0000, 1.0000, 1.0000, 1.0000
micros: 0.3409, 0.7740, 0.8178, 0.8729, 2.3235
```
