### PR TITLE
Small cleanup. Use fxHash instead

### DIFF
--- a/src/extract/bottom_up.rs
+++ b/src/extract/bottom_up.rs
@@ -4,7 +4,10 @@ pub struct BottomUpExtractor;
 impl Extractor for BottomUpExtractor {
     fn extract(&self, egraph: &EGraph, _roots: &[ClassId]) -> ExtractionResult {
         let mut result = ExtractionResult::default();
-        let mut costs = IndexMap::<ClassId, Cost>::default();
+        let mut costs = FxHashMap::<ClassId, Cost>::with_capacity_and_hasher(
+            egraph.classes().len(),
+            Default::default(),
+        );
         let mut did_something = false;
 
         loop {

--- a/src/extract/faster_bottom_up.rs
+++ b/src/extract/faster_bottom_up.rs
@@ -14,9 +14,9 @@ use super::*;
 /// This algorithm instead only visits the nodes whose current cost estimate may change:
 /// it does this by tracking parent-child relationships and storing relevant nodes
 /// in a work list (UniqueQueue).
-pub struct BottomUpExtractor;
+pub struct FasterBottomUpExtractor;
 
-impl Extractor for BottomUpExtractor {
+impl Extractor for FasterBottomUpExtractor {
     fn extract(&self, egraph: &EGraph, _roots: &[ClassId]) -> ExtractionResult {
         let mut parents = IndexMap::<ClassId, Vec<NodeId>>::with_capacity(egraph.classes().len());
         let n2c = |nid: &NodeId| egraph.nid_to_cid(nid);

--- a/src/extract/faster_greedy_dag.rs
+++ b/src/extract/faster_greedy_dag.rs
@@ -6,7 +6,8 @@ use super::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 struct CostSet {
-    costs: FxHashMap<ClassId, Cost>,
+    // It's slightly faster if this is an HashMap rather than an fxHashMap.
+    costs: HashMap<ClassId, Cost>,
     total: Cost,
     choice: NodeId,
 }

--- a/src/extract/faster_greedy_dag.rs
+++ b/src/extract/faster_greedy_dag.rs
@@ -3,9 +3,10 @@
 // included in the cost.
 
 use super::*;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 struct CostSet {
-    costs: std::collections::HashMap<ClassId, Cost>,
+    costs: FxHashMap<ClassId, Cost>,
     total: Cost,
     choice: NodeId,
 }
@@ -16,7 +17,7 @@ impl FasterGreedyDagExtractor {
     fn calculate_cost_set(
         egraph: &EGraph,
         node_id: NodeId,
-        costs: &HashMap<ClassId, CostSet>,
+        costs: &FxHashMap<ClassId, CostSet>,
         best_cost: Cost,
     ) -> CostSet {
         let node = &egraph[&node_id];
@@ -24,7 +25,7 @@ impl FasterGreedyDagExtractor {
         // No children -> easy.
         if node.children.is_empty() {
             return CostSet {
-                costs: std::collections::HashMap::default(),
+                costs: Default::default(),
                 total: node.cost,
                 choice: node_id.clone(),
             };
@@ -44,7 +45,7 @@ impl FasterGreedyDagExtractor {
         if childrens_classes.len() == 1 && (node.cost + first_cost.total > best_cost) {
             // Shortcut. Can't be cheaper so return junk.
             return CostSet {
-                costs: std::collections::HashMap::default(),
+                costs: Default::default(),
                 total: INFINITY,
                 choice: node_id.clone(),
             };
@@ -85,46 +86,35 @@ impl FasterGreedyDagExtractor {
     }
 }
 
-impl FasterGreedyDagExtractor {
-    fn check(egraph: &EGraph, node_id: NodeId, costs: &HashMap<ClassId, CostSet>) {
-        let cid = egraph.nid_to_cid(&node_id);
-        let previous = costs.get(cid).unwrap().total;
-        let cs = Self::calculate_cost_set(egraph, node_id, costs, INFINITY);
-        println!("{} {}", cs.total, previous);
-        assert!(cs.total >= previous);
-    }
-}
-
 impl Extractor for FasterGreedyDagExtractor {
     fn extract(&self, egraph: &EGraph, _roots: &[ClassId]) -> ExtractionResult {
-        // 1. build map from class to parent nodes
-        let mut parents = IndexMap::<ClassId, Vec<NodeId>>::default();
+        let mut parents = IndexMap::<ClassId, Vec<NodeId>>::with_capacity(egraph.classes().len());
         let n2c = |nid: &NodeId| egraph.nid_to_cid(nid);
+        let mut analysis_pending = UniqueQueue::default();
 
         for class in egraph.classes().values() {
             parents.insert(class.id.clone(), Vec::new());
         }
+
         for class in egraph.classes().values() {
             for node in &class.nodes {
                 for c in &egraph[node].children {
+                    // compute parents of this enode
                     parents[n2c(c)].push(node.clone());
                 }
-            }
-        }
 
-        // 2. start analysis from leaves
-        let mut analysis_pending = UniqueQueue::default();
-
-        for class in egraph.classes().values() {
-            for node in &class.nodes {
+                // start the analysis from leaves
                 if egraph[node].is_leaf() {
                     analysis_pending.insert(node.clone());
                 }
             }
         }
 
-        // 3. analyse from leaves towards parents until fixpoint
-        let mut costs = HashMap::<ClassId, CostSet>::default();
+        let mut result = ExtractionResult::default();
+        let mut costs = FxHashMap::<ClassId, CostSet>::with_capacity_and_hasher(
+            egraph.classes().len(),
+            Default::default(),
+        );
 
         while let Some(node_id) = analysis_pending.pop() {
             let class_id = n2c(&node_id);
@@ -144,15 +134,6 @@ impl Extractor for FasterGreedyDagExtractor {
             }
         }
 
-        /*
-                for class in egraph.classes().values() {
-                    for node in &class.nodes {
-                        Self::check(&egraph, node.clone(), &costs);
-                    }
-                }
-        */
-
-        let mut result = ExtractionResult::default();
         for (cid, cost_set) in costs {
             result.choose(cid, cost_set.choice);
         }
@@ -164,6 +145,8 @@ impl Extractor for FasterGreedyDagExtractor {
 /** A data structure to maintain a queue of unique elements.
 
 Notably, insert/pop operations have O(1) expected amortized runtime complexity.
+
+Thanks @Bastacyclop for the implementation!
 */
 #[derive(Clone)]
 #[cfg_attr(feature = "serde-1", derive(Serialize, Deserialize))]
@@ -171,7 +154,7 @@ pub(crate) struct UniqueQueue<T>
 where
     T: Eq + std::hash::Hash + Clone,
 {
-    set: std::collections::HashSet<T>, // hashbrown::
+    set: FxHashSet<T>, // hashbrown::
     queue: std::collections::VecDeque<T>,
 }
 
@@ -181,7 +164,7 @@ where
 {
     fn default() -> Self {
         UniqueQueue {
-            set: std::collections::HashSet::default(),
+            set: Default::default(),
             queue: std::collections::VecDeque::new(),
         }
     }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -6,10 +6,9 @@ pub use crate::*;
 
 pub mod bottom_up;
 pub mod faster_bottom_up;
+pub mod faster_greedy_dag;
 pub mod global_greedy_dag;
 pub mod greedy_dag;
-pub mod greedy_dag_1;
-
 #[cfg(feature = "ilp-cbc")]
 pub mod ilp_cbc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
         ("bottom-up", extract::bottom_up::BottomUpExtractor.boxed()),
         (
             "faster-bottom-up",
-            extract::faster_bottom_up::BottomUpExtractor.boxed(),
+            extract::faster_bottom_up::FasterBottomUpExtractor.boxed(),
         ),
         (
             "greedy-dag",
@@ -30,7 +30,7 @@ fn main() {
         ),
         (
             "faster-greedy-dag",
-            extract::greedy_dag_1::FasterGreedyDagExtractor.boxed(),
+            extract::faster_greedy_dag::FasterGreedyDagExtractor.boxed(),
         ),
         (
             "global-greedy-dag",


### PR DESCRIPTION
* Uses fxhash to store the costs,
* Takes similar time or is slightly faster,
* Gives the same results,
* Renames the file containing the faster greedy dag extractor
* 

```
###################################################
greedy-dag vs greedy-dag-old


extractors: ['greedy-dag', 'greedy-dag-old']
cumulative time for greedy-dag: 33521ms
cumulative time for greedy-dag-old: 36672ms
cumulative tree cost for greedy-dag: 32017750408986
cumulative tree cost for greedy-dag-old: 32017750408986
cumulative dag cost for greedy-dag: 76907
cumulative dag cost for greedy-dag-old: 76907
Cumulative time for greedy-dag: 33521ms
Cumulative time for greedy-dag-old: 36672ms
greedy-dag / greedy-dag-old
geo mean
tree: 1.0000
dag: 1.0000
micros: 0.9384
quantiles
tree:   1.0000, 1.0000, 1.0000, 1.0000, 1.0000
dag:    1.0000, 1.0000, 1.0000, 1.0000, 1.0000
micros: 0.3897, 0.8423, 0.9043, 1.0635, 2.1116
```

```
###################################################
bottom-up vs bottom-up-old


extractors: ['bottom-up', 'bottom-up-old']
cumulative time for bottom-up: 3437ms
cumulative time for bottom-up-old: 4349ms
cumulative tree cost for bottom-up: 18584377265237
cumulative tree cost for bottom-up-old: 18584377265237
cumulative dag cost for bottom-up: 77915
cumulative dag cost for bottom-up-old: 77915
Cumulative time for bottom-up: 3437ms
Cumulative time for bottom-up-old: 4349ms
bottom-up / bottom-up-old
geo mean
tree: 1.0000
dag: 1.0000
micros: 0.7792
quantiles
tree:   1.0000, 1.0000, 1.0000, 1.0000, 1.0000
dag:    1.0000, 1.0000, 1.0000, 1.0000, 1.0000
micros: 0.2834, 0.6136, 0.8002, 0.8825, 2.8000
```


```
###################################################
faster-greedy-dag vs faster-greedy-dag-old


extractors: ['faster-greedy-dag', 'faster-greedy-dag-old']
cumulative time for faster-greedy-dag: 2945ms
cumulative time for faster-greedy-dag-old: 2936ms
cumulative tree cost for faster-greedy-dag: 32017750409008
cumulative tree cost for faster-greedy-dag-old: 32017750409008
cumulative dag cost for faster-greedy-dag: 77029
cumulative dag cost for faster-greedy-dag-old: 77029
Cumulative time for faster-greedy-dag: 2945ms
Cumulative time for faster-greedy-dag-old: 2936ms
faster-greedy-dag / faster-greedy-dag-old
geo mean
tree: 1.0000
dag: 1.0000
micros: 1.0002
quantiles
tree:   1.0000, 1.0000, 1.0000, 1.0000, 1.0000
dag:    1.0000, 1.0000, 1.0000, 1.0000, 1.0000
micros: 0.3750, 0.9367, 0.9969, 1.0209, 2.0588


```

```
###################################################
faster-bottom-up vs faster-bottom-up-old


extractors: ['faster-bottom-up', 'faster-bottom-up-old']
cumulative time for faster-bottom-up: 1493ms
cumulative time for faster-bottom-up-old: 1565ms
cumulative tree cost for faster-bottom-up: 18584377265237
cumulative tree cost for faster-bottom-up-old: 18584377265237
cumulative dag cost for faster-bottom-up: 78037
cumulative dag cost for faster-bottom-up-old: 78037
Cumulative time for faster-bottom-up: 1493ms
Cumulative time for faster-bottom-up-old: 1565ms
faster-bottom-up / faster-bottom-up-old
geo mean
tree: 1.0000
dag: 1.0000
micros: 0.9543
quantiles
tree:   1.0000, 1.0000, 1.0000, 1.0000, 1.0000
dag:    1.0000, 1.0000, 1.0000, 1.0000, 1.0000
micros: 0.4363, 0.5649, 1.0049, 1.0951, 2.8000
```

