### PR TITLE
Add good_lp based (with highs solver) extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,12 +34,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "bitmaps"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -65,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "extraction-gym"
 version = "0.1.0"
 dependencies = [
@@ -87,12 +185,36 @@ dependencies = [
  "coin_cbc",
  "egraph-serialize",
  "env_logger",
+ "good_lp",
  "im-rc",
  "indexmap",
  "log",
  "ordered-float",
  "pico-args",
  "rpds",
+ "rustc-hash",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "good_lp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa124423ded10046a849fa0ae9747c541895557f1af177e0890b09879e7e9e7d"
+dependencies = [
+ "fnv",
+ "highs",
 ]
 
 [[package]]
@@ -100,6 +222,35 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
+name = "highs"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c34cc5d9c2d42deda5b35cd9d89bb0cded0fe7122ec29d534d074a522c16e7c"
+dependencies = [
+ "highs-sys",
+ "log",
+]
+
+[[package]]
+name = "highs-sys"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9864d7b1f74b8445be610ea06c89095b629e045b4eb56e0f34e362d7fadbf8b5"
+dependencies = [
+ "bindgen",
+ "cmake",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "im-rc"
@@ -139,10 +290,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-traits"
@@ -171,6 +372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +388,16 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -229,12 +446,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rpds"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0e15515d3ce3313324d842629ea4905c25a13f81953eadb88f85516f59290a4"
 dependencies = [
  "archery",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -276,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,9 +564,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -325,3 +596,103 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [features]
 ilp-cbc = ["coin_cbc"]
+ilp-highs = ["good_lp"]
 
 [dependencies]
 env_logger = { version = "0.10.0", default-features = false }
@@ -17,6 +18,7 @@ pico-args = { version = "0.5.0", features = ["eq-separator"] }
 
 anyhow = "1.0.71"
 coin_cbc = { version = "0.1.6", optional = true }
+good_lp = { version = "1.7.0", default-features = false, features = ["highs"], optional = true }
 im-rc = "15.1.0"
 rustc-hash = "1.1.0"
 

--- a/src/extract/ilp/cbc.rs
+++ b/src/extract/ilp/cbc.rs
@@ -1,8 +1,7 @@
-use core::panic;
-
-use super::*;
 use coin_cbc::{Col, Model, Sense};
 use indexmap::IndexSet;
+
+use super::*;
 
 const INITIALISE_WITH_BOTTOM_UP: bool = false;
 
@@ -174,94 +173,6 @@ impl Extractor for CbcExtractor {
 
         let cycles = result.find_cycles(egraph, roots);
         assert!(cycles.is_empty());
-        return result;
+        result
     }
-}
-
-// from @khaki3
-// fixes bug in egg 0.9.4's version
-// https://github.com/egraphs-good/egg/issues/207#issuecomment-1264737441
-fn find_cycles(egraph: &EGraph, mut f: impl FnMut(ClassId, usize)) {
-    let mut pending: IndexMap<ClassId, Vec<(ClassId, usize)>> = IndexMap::default();
-
-    let mut order: IndexMap<ClassId, usize> = IndexMap::default();
-
-    let mut memo: IndexMap<(ClassId, usize), bool> = IndexMap::default();
-
-    let mut stack: Vec<(ClassId, usize)> = vec![];
-
-    let n2c = |nid: &NodeId| egraph.nid_to_cid(nid);
-
-    for class in egraph.classes().values() {
-        let id = &class.id;
-        for (i, node_id) in egraph[id].nodes.iter().enumerate() {
-            let node = &egraph[node_id];
-            for child in &node.children {
-                let child = n2c(child).clone();
-                pending
-                    .entry(child)
-                    .or_insert_with(Vec::new)
-                    .push((id.clone(), i));
-            }
-
-            if node.is_leaf() {
-                stack.push((id.clone(), i));
-            }
-        }
-    }
-
-    let mut count = 0;
-
-    while let Some((id, i)) = stack.pop() {
-        if memo.get(&(id.clone(), i)).is_some() {
-            continue;
-        }
-
-        let node_id = &egraph[&id].nodes[i];
-        let node = &egraph[node_id];
-        let mut update = false;
-
-        if node.is_leaf() {
-            update = true;
-        } else if node.children.iter().all(|x| order.get(n2c(x)).is_some()) {
-            if let Some(ord) = order.get(&id) {
-                update = node.children.iter().all(|x| &order[n2c(x)] < ord);
-                if !update {
-                    memo.insert((id, i), false);
-                    continue;
-                }
-            } else {
-                update = true;
-            }
-        }
-
-        if update {
-            if order.get(&id).is_none() {
-                if egraph[node_id].is_leaf() {
-                    order.insert(id.clone(), 0);
-                } else {
-                    order.insert(id.clone(), count);
-                    count += 1;
-                }
-            }
-            memo.insert((id.clone(), i), true);
-            if let Some(mut v) = pending.remove(&id) {
-                stack.append(&mut v);
-                stack.sort();
-                stack.dedup();
-            };
-        }
-    }
-
-    for class in egraph.classes().values() {
-        let id = &class.id;
-        for (i, node) in class.nodes.iter().enumerate() {
-            if let Some(true) = memo.get(&(id.clone(), i)) {
-                continue;
-            }
-            assert!(!egraph[node].is_leaf());
-            f(id.clone(), i);
-        }
-    }
-    assert!(pending.is_empty());
 }

--- a/src/extract/ilp/highs.rs
+++ b/src/extract/ilp/highs.rs
@@ -1,0 +1,162 @@
+use good_lp::{*, solvers::highs::*};
+use indexmap::IndexSet;
+
+use super::*;
+
+struct ClassVars {
+    active: Variable,
+    nodes: Vec<Variable>,
+}
+
+pub struct HighsExtractor;
+
+impl Extractor for HighsExtractor {
+    fn extract(&self, egraph: &egraph_serialize::EGraph, roots: &[ClassId]) -> ExtractionResult {
+        let mut problem_vars = ProblemVariables::new();
+        let mut constraints = Vec::new();
+
+        let true_literal = problem_vars.add(variable().binary());
+        constraints.push(constraint!(true_literal == 1.0));
+
+        let vars: IndexMap<ClassId, ClassVars> = egraph
+            .classes()
+            .values()
+            .map(|class| {
+                let cvars = ClassVars {
+                    active: if roots.contains(&class.id) {
+                        // Roots must be active.
+                        true_literal
+                    } else {
+                        problem_vars.add(variable().binary())
+                    },
+                    nodes: class
+                        .nodes
+                        .iter()
+                        .map(|_| problem_vars.add(variable().binary()))
+                        .collect(),
+                };
+                (class.id.clone(), cvars)
+            })
+            .collect();
+
+        for (class_id, class) in &vars {
+            // class active == some node active
+            // sum(for node_active in class) == class_active
+            let mut row = -class.active;
+            for &node_active in &class.nodes {
+                row += node_active;
+            }
+            constraints.push(constraint!(row == 0.0));
+
+            let childrens_classes_var = |nid: NodeId| {
+                egraph[&nid]
+                    .children
+                    .iter()
+                    .map(|n| egraph[n].eclass.clone())
+                    .map(|n| vars[&n].active)
+                    .collect::<IndexSet<_>>()
+            };
+
+            let mut intersection: IndexSet<_> =
+                childrens_classes_var(egraph[class_id].nodes[0].clone());
+
+            for node in &egraph[class_id].nodes[1..] {
+                intersection = intersection
+                    .intersection(&childrens_classes_var(node.clone()))
+                    .copied()
+                    .collect();
+            }
+
+            // A class being active implies that all in the intersection
+            // of it's children are too.
+            for c in &intersection {
+                let row = class.active - *c;
+                constraints.push(constraint!(row <= 0.0));
+            }
+
+            for (node_id, &node_active) in egraph[class_id].nodes.iter().zip(&class.nodes) {
+                for child_active in childrens_classes_var(node_id.clone()) {
+                    // node active implies child active, encoded as:
+                    //   node_active <= child_active
+                    //   node_active - child_active <= 0
+                    if !intersection.contains(&child_active) {
+                        let row = node_active - child_active;
+                        constraints.push(constraint!(row <= 0.0));
+                    }
+                }
+            }
+        }
+
+        let mut total_cost = Expression::from(0);
+
+        for class in egraph.classes().values() {
+            let min_cost = class
+                .nodes
+                .iter()
+                .map(|n_id| egraph[n_id].cost)
+                .min()
+                .unwrap_or_else(Cost::default)
+                .into_inner();
+
+            // Most helpful when the members of the class all have the same cost.
+            // For example if the members' costs are [1,1,1], three terms get
+            // replaced by one in the objective function.
+            if min_cost != 0.0 {
+                total_cost += vars[&class.id].active * min_cost;
+            }
+
+            for (node_id, &node_active) in class.nodes.iter().zip(&vars[&class.id].nodes) {
+                let node = &egraph[node_id];
+                let node_cost = node.cost.into_inner() - min_cost;
+                assert!(node_cost >= 0.0);
+
+                if node_cost != 0.0 {
+                    total_cost += node_active * node_cost;
+                }
+            }
+        }
+
+        let mut banned_cycles: IndexSet<(ClassId, usize)> = IndexSet::default();
+        find_cycles(egraph, |id, i| {
+            banned_cycles.insert((id, i));
+        });
+        for (class_id, class_vars) in &vars {
+            for (i, &node_active) in class_vars.nodes.iter().enumerate() {
+                if banned_cycles.contains(&(class_id.clone(), i)) {
+                    constraints.push(constraint!(node_active == 0.0));
+                }
+            }
+        }
+        log::info!("@blocked {}", banned_cycles.len());
+
+        let problem = constraints.into_iter().fold(
+            problem_vars
+                .minimise(total_cost)
+                .using(good_lp::default_solver),
+            |acc, constraint| acc.with(constraint),
+        );
+        let mut problem = problem.set_parallel(HighsParallelType::On);
+        problem.set_verbose(true);
+
+        let solution = problem.solve().unwrap();
+
+        let mut result = ExtractionResult::default();
+
+        for (id, var) in &vars {
+            let active = (solution.value(var.active) - 1.0).abs() < 0.1;
+            if active {
+                let node_idx = var
+                    .nodes
+                    .iter()
+                    .position(|&n| (solution.value(n) - 1.0).abs() < 0.1)
+                    .unwrap();
+                let node_id = egraph[id].nodes[node_idx].clone();
+                result.choose(id.clone(), node_id);
+            }
+        }
+
+        let cycles = result.find_cycles(egraph, roots);
+        assert!(cycles.is_empty());
+        result
+    }
+}

--- a/src/extract/ilp/mod.rs
+++ b/src/extract/ilp/mod.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[cfg(feature = "ilp-cbc")]
+pub mod cbc;
+#[cfg(feature = "ilp-highs")]
+pub mod highs;
+
+// from @khaki3
+// fixes bug in egg 0.9.4's version
+// https://github.com/egraphs-good/egg/issues/207#issuecomment-1264737441
+fn find_cycles(egraph: &EGraph, mut f: impl FnMut(ClassId, usize)) {
+    let mut pending: IndexMap<ClassId, Vec<(ClassId, usize)>> = IndexMap::default();
+
+    let mut order: IndexMap<ClassId, usize> = IndexMap::default();
+
+    let mut memo: IndexMap<(ClassId, usize), bool> = IndexMap::default();
+
+    let mut stack: Vec<(ClassId, usize)> = vec![];
+
+    let n2c = |nid: &NodeId| egraph.nid_to_cid(nid);
+
+    for class in egraph.classes().values() {
+        let id = &class.id;
+        for (i, node_id) in egraph[id].nodes.iter().enumerate() {
+            let node = &egraph[node_id];
+            for child in &node.children {
+                let child = n2c(child).clone();
+                pending
+                    .entry(child)
+                    .or_default()
+                    .push((id.clone(), i));
+            }
+
+            if node.is_leaf() {
+                stack.push((id.clone(), i));
+            }
+        }
+    }
+
+    let mut count = 0;
+
+    while let Some((id, i)) = stack.pop() {
+        if memo.get(&(id.clone(), i)).is_some() {
+            continue;
+        }
+
+        let node_id = &egraph[&id].nodes[i];
+        let node = &egraph[node_id];
+        let mut update = false;
+
+        if node.is_leaf() {
+            update = true;
+        } else if node.children.iter().all(|x| order.get(n2c(x)).is_some()) {
+            if let Some(ord) = order.get(&id) {
+                update = node.children.iter().all(|x| &order[n2c(x)] < ord);
+                if !update {
+                    memo.insert((id, i), false);
+                    continue;
+                }
+            } else {
+                update = true;
+            }
+        }
+
+        if update {
+            if order.get(&id).is_none() {
+                if egraph[node_id].is_leaf() {
+                    order.insert(id.clone(), 0);
+                } else {
+                    order.insert(id.clone(), count);
+                    count += 1;
+                }
+            }
+            memo.insert((id.clone(), i), true);
+            if let Some(mut v) = pending.remove(&id) {
+                stack.append(&mut v);
+                stack.sort();
+                stack.dedup();
+            };
+        }
+    }
+
+    for class in egraph.classes().values() {
+        let id = &class.id;
+        for (i, node) in class.nodes.iter().enumerate() {
+            if let Some(true) = memo.get(&(id.clone(), i)) {
+                continue;
+            }
+            assert!(!egraph[node].is_leaf());
+            f(id.clone(), i);
+        }
+    }
+    assert!(pending.is_empty());
+}

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -9,8 +9,8 @@ pub mod faster_bottom_up;
 pub mod faster_greedy_dag;
 pub mod global_greedy_dag;
 pub mod greedy_dag;
-#[cfg(feature = "ilp-cbc")]
-pub mod ilp_cbc;
+#[cfg(any(feature = "ilp-cbc", feature = "ilp-highs"))]
+pub mod ilp;
 
 pub trait Extractor: Sync {
     fn extract(&self, egraph: &EGraph, roots: &[ClassId]) -> ExtractionResult;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,10 @@ fn main() {
             "global-greedy-dag",
             extract::global_greedy_dag::GlobalGreedyDagExtractor.boxed(),
         ),
+        #[cfg(feature = "ilp-cbc")]
+        ("ilp-cbc", extract::ilp::cbc::CbcExtractor.boxed()),
+        #[cfg(feature = "ilp-highs")]
+        ("ilp-highs", extract::ilp::highs::HighsExtractor.boxed()),
     ]
     .into_iter()
     .collect();


### PR DESCRIPTION
This is a port of cbc extractor to good_lp rust library with highs ilp solver. It is faster and requires no runtime deps (highs links statically). Also good_lp based extractor is solver-agnostic and ilp solver can be easily changed.

Bench results:
```
cumulative time for ilp-cbc: 219968ms
cumulative time for ilp-highs: 145051ms
cumulative tree cost for ilp-cbc: 35474620331874
cumulative tree cost for ilp-highs: 35474620326221
cumulative dag cost for ilp-cbc: 118031
cumulative dag cost for ilp-highs: 118031
```